### PR TITLE
Add Flutter requirement and setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # telodoy
+
+This project requires the [Flutter](https://flutter.dev) SDK which includes the Dart tools.
+Please follow the official installation guide for your platform:
+<https://docs.flutter.dev/get-started/install>.
+
+For convenience, a simple setup script is provided in `scripts/install_flutter.sh`.
+It installs Flutter on Linux and adds it to the `PATH` for the current session.
+Run it with:
+
+```bash
+scripts/install_flutter.sh
+```
+
+After installation you can verify your setup with `flutter doctor`.
+

--- a/scripts/install_flutter.sh
+++ b/scripts/install_flutter.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Simple setup script to install Flutter and Dart on Linux
+# Not for production use. Adjust as needed for your environment.
+set -e
+if [ "$(uname)" != "Linux" ]; then
+  echo "This setup script currently supports only Linux." >&2
+  exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install -y curl unzip xz-utils git
+
+FLUTTER_VERSION="3.13.6"
+FLUTTER_ARCHIVE="flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
+if [ ! -f "$FLUTTER_ARCHIVE" ]; then
+  curl -O "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/${FLUTTER_ARCHIVE}"
+fi
+
+mkdir -p "${HOME}/development"
+tar xf "$FLUTTER_ARCHIVE" -C "${HOME}/development"
+
+export PATH="${HOME}/development/flutter/bin:${PATH}"
+echo "Flutter installed at ${HOME}/development/flutter" >&2
+echo "Add the following line to your shell profile to permanently update PATH:" >&2
+echo 'export PATH="$HOME/development/flutter/bin:$PATH"' >&2
+
+flutter doctor


### PR DESCRIPTION
## Summary
- document Flutter/Dart requirement and link to the official install guide
- add a simple Linux setup script to install Flutter SDK

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fbc9af5748322a2d72bbc81e22c93