### PR TITLE
Update Android NDK version

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.example.telodoy"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
## Summary
- specify the NDK version directly in `android/app/build.gradle.kts`

## Testing
- `flutter pub get`
- `flutter build apk` *(fails: No Android SDK found)*
- `flutter analyze` *(fails: multiple analysis issues)*

------
https://chatgpt.com/codex/tasks/task_e_68608dbc18088322bc3d6cd0ceed20cc