### PR TITLE
Fix macOS network error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ flutter run
 ```
 
 The app will display other devices running Telodoy on the same network. Tap a peer to select a file and send it.
+
+### macOS permissions
+
+When building for macOS the app runs inside the sandbox. The entitlements files
+have been configured to allow both network client and server access. If you
+modify the project, ensure `com.apple.security.network.client` and
+`com.apple.security.network.server` remain enabled so discovery works correctly.

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,7 +6,9 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
+        <key>com.apple.security.network.client</key>
+        <true/>
+        <key>com.apple.security.network.server</key>
+        <true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -2,7 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
+        <key>com.apple.security.app-sandbox</key>
+        <true/>
+        <key>com.apple.security.network.client</key>
+        <true/>
+        <key>com.apple.security.network.server</key>
+        <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- enable network client/server entitlements for macOS
- document macOS network permission requirements

## Testing
- `dart format lib`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6860f2b72504832292ff28539e7f897b