### PR TITLE
Add manual IP connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Telodoy is a cross-platform file sharing app built with Flutter. It allows users
 - List available peers and select one to send files.
 - Works on macOS, Linux and Android.
 - On-screen debug log shows discovery events.
+- Display your device's IP and manually connect to another IP.
 
 ## Getting Started
 
@@ -20,6 +21,7 @@ flutter run
 ```
 
 The app will display other devices running Telodoy on the same network. Tap a peer to select a file and send it.
+You can also use the link icon to enter an IP address and connect directly. Once connected, devices automatically exchange an emoji.
 
 ### macOS permissions
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,23 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 
+const int connectionPort = 5678;
+
+Future<String?> getLocalIp() async {
+  final interfaces = await NetworkInterface.list(
+    type: InternetAddressType.IPv4,
+    includeLoopback: false,
+  );
+  for (final interface in interfaces) {
+    for (final addr in interface.addresses) {
+      if (!addr.isLoopback && addr.type == InternetAddressType.IPv4) {
+        return addr.address;
+      }
+    }
+  }
+  return null;
+}
+
 void main() {
   runApp(const MyApp());
 }
@@ -78,6 +95,45 @@ class DiscoveryService {
   }
 }
 
+class ConnectionService {
+  ConnectionService({this.onLog});
+
+  final void Function(String)? onLog;
+  ServerSocket? _server;
+
+  Future<void> start() async {
+    _server = await ServerSocket.bind(InternetAddress.anyIPv4, connectionPort);
+    onLog?.call('Listening on ${_server!.address.address}:$connectionPort');
+    _server!.listen(_handleClient);
+  }
+
+  void _handleClient(Socket client) {
+    onLog?.call('Client connected from ${client.remoteAddress.address}');
+    client.writeln('👋');
+    client.flush();
+    client.listen(
+      (data) => onLog?.call(
+        'Received: ${utf8.decode(data).trim()} from ${client.remoteAddress.address}',
+      ),
+      onDone: client.destroy,
+    );
+  }
+
+  Future<void> connect(String ip) async {
+    final socket = await Socket.connect(ip, connectionPort);
+    socket.listen(
+      (data) => onLog?.call('Received: ${utf8.decode(data).trim()} from $ip'),
+      onDone: socket.destroy,
+    );
+    socket.writeln('🙂');
+    await socket.flush();
+  }
+
+  void dispose() {
+    _server?.close();
+  }
+}
+
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
 
@@ -87,6 +143,8 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   late final DiscoveryService _discovery;
+  late final ConnectionService _connection;
+  String? _localIp;
   final List<String> _logs = [];
 
   void _addLog(String msg) {
@@ -99,12 +157,20 @@ class _HomePageState extends State<HomePage> {
   void initState() {
     super.initState();
     _discovery = DiscoveryService(onLog: _addLog);
+    _connection = ConnectionService(onLog: _addLog);
     _discovery.start();
+    _connection.start();
+    getLocalIp().then((ip) {
+      setState(() {
+        _localIp = ip;
+      });
+    });
   }
 
   @override
   void dispose() {
     _discovery.dispose();
+    _connection.dispose();
     super.dispose();
   }
 
@@ -122,15 +188,58 @@ class _HomePageState extends State<HomePage> {
     await socket.close();
   }
 
+  Future<void> _promptAndConnect() async {
+    final controller = TextEditingController();
+    final ip = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Connect to IP'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(hintText: 'Enter IP address'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(controller.text),
+            child: const Text('Connect'),
+          ),
+        ],
+      ),
+    );
+    if (ip != null && ip.isNotEmpty) {
+      _addLog('Connecting to $ip');
+      await _connection.connect(ip);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Telodoy Peers')),
+      appBar: AppBar(
+        title: const Text('Telodoy Peers'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.link),
+            onPressed: _promptAndConnect,
+          ),
+        ],
+      ),
       body: Column(
         children: [
           Padding(
             padding: const EdgeInsets.all(8),
-            child: Text('Peers found: ${_discovery.peers.length}'),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (_localIp != null) Text("Your IP: $_localIp"),
+                const SizedBox(height: 4),
+                Text("Peers found: ${_discovery.peers.length}"),
+              ],
+            ),
           ),
           Expanded(
             child: ListView.builder(
@@ -150,18 +259,17 @@ class _HomePageState extends State<HomePage> {
               padding: const EdgeInsets.all(8),
               height: 120,
               child: ListView(
-                children:
-                    _logs
-                        .map(
-                          (l) => Text(
-                            l,
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 12,
-                            ),
-                          ),
-                        )
-                        .toList(),
+                children: _logs
+                    .map(
+                      (l) => Text(
+                        l,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                        ),
+                      ),
+                    )
+                    .toList(),
               ),
             ),
         ],


### PR DESCRIPTION
## Summary
- display local IP address in the UI
- allow entering another device's IP via dialog (link icon)
- add `ConnectionService` to exchange emoji when connecting directly
- document manual connection feature in README

## Testing
- `dart format lib/main.dart`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6860f8f3eb9c8322ac08bca1110050d3