### PR TITLE
Fix Android network error

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ You can also use the link icon to enter an IP address and connect directly. Once
 connected, devices automatically exchange an emoji. On Android, ensure the
 device is connected to Wi-Fi so its IP can be detected.
 
+### Android permissions
+
+The release version of the app requires the `INTERNET` permission to open
+network sockets. Ensure the following line is present in
+`android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.INTERNET"/>
+```
+
 
 ### macOS permissions
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="telodoy"
         android:name="${applicationName}"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,13 +63,15 @@ class DiscoveryService {
   final void Function(String)? onLog;
   RawDatagramSocket? _socket;
   StreamSubscription<RawSocketEvent>? _subscription;
+  Timer? _announceTimer;
 
   Future<void> start() async {
     _socket = await RawDatagramSocket.bind(InternetAddress.anyIPv4, 0);
     _socket!.broadcastEnabled = true;
     _subscription = _socket!.listen(_handleEvent);
     onLog?.call('Discovery started on port ${_socket!.port}');
-    Timer.periodic(const Duration(seconds: 2), (_) => announce());
+    _announceTimer =
+        Timer.periodic(const Duration(seconds: 2), (_) => announce());
   }
 
   void announce() {
@@ -97,6 +99,7 @@ class DiscoveryService {
   }
 
   void dispose() {
+    _announceTimer?.cancel();
     _subscription?.cancel();
     _socket?.close();
   }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,26 +5,16 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:telodoy/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('Home page shows peer list title', (WidgetTester tester) async {
+    // Build the app and trigger a frame.
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the title is present.
+    expect(find.text('Telodoy Peers'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add Internet permission for Android
- cancel discovery timer on dispose
- simplify widget test to check title
- document required Android permissions

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6861043780888322881a16c6e0b58baa