### PR TITLE
Add sending files after establishing connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Telodoy is a cross-platform file sharing app built with Flutter. It allows users
 - On-screen debug log shows discovery events.
 - Display your device's IP and manually connect to another IP. Connection
   attempts show success or failure in the debug log.
+- After connecting, use the attach file icon to send a file through the
+  established link.
 
 
 ## Getting Started
@@ -24,8 +26,9 @@ flutter run
 
 The app will display other devices running Telodoy on the same network. Tap a peer to select a file and send it.
 You can also use the link icon to enter an IP address and connect directly. Once
-connected, devices automatically exchange an emoji. On Android, ensure the
-device is connected to Wi-Fi so its IP can be detected.
+connected, devices automatically exchange an emoji and the attach file icon
+becomes enabled for sending data. On Android, ensure the device is connected to
+Wi-Fi so its IP can be detected.
 
 ### Android permissions
 


### PR DESCRIPTION
## Summary
- track connection state in `ConnectionService`
- enable sending files over an established connection
- add UI button to select and send file when connected
- document new feature in README

## Testing
- `dart format lib/main.dart`
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68610a25686083228aee4cd7cde880f9