### PR TITLE
Enable macOS file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,6 @@ When building for macOS the app runs inside the sandbox. The entitlements files
 have been configured to allow both network client and server access. If you
 modify the project, ensure `com.apple.security.network.client` and
 `com.apple.security.network.server` remain enabled so discovery works correctly.
+To access files chosen via the dialog and save incoming files in `Downloads`
+also enable `com.apple.security.files.user-selected.read-write` and
+`com.apple.security.files.downloads.read-write`.

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,5 +10,9 @@
         <true/>
         <key>com.apple.security.network.server</key>
         <true/>
+        <key>com.apple.security.files.user-selected.read-write</key>
+        <true/>
+        <key>com.apple.security.files.downloads.read-write</key>
+        <true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -8,5 +8,9 @@
         <true/>
         <key>com.apple.security.network.server</key>
         <true/>
+        <key>com.apple.security.files.user-selected.read-write</key>
+        <true/>
+        <key>com.apple.security.files.downloads.read-write</key>
+        <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- allow Telodoy to read user selected files and write to Downloads on macOS
- document new macOS entitlements in the README

## Testing
- `dart format lib`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6862575ef33c832297be330c8b479a00