### PR TITLE
Add settings screen and persistent download path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Telodoy is a cross-platform file sharing app built with Flutter. It allows users
 - On-screen debug log shows discovery events.
 - Display your device's IP and manually connect to another IP. Connection
   attempts show success or failure in the debug log.
-- After connecting, use the attach file icon to send a file through the
-  established link.
+- After connecting, use the menu to send a file through the established link.
 - When connected, the remote IP and greeting emoji are shown.
-- Received files are saved to your system's Downloads folder and a progress bar
-  indicates transfer status. Each incoming file displays its own progress bar
-  with the file name and you can tap it to see the file size and location.
+- Received files are saved in your chosen directory (defaulting to Downloads).
+  Each incoming file shows its own progress bar and you can tap the file name
+  to open it with your system's default application.
+- A Settings screen lets you pick the folder used to store transfers and the
+  choice persists between launches.
 
 
 ## Getting Started
@@ -30,9 +31,9 @@ flutter run
 
 The app will display other devices running Telodoy on the same network. Tap a peer to select a file and send it.
 You can also use the link icon to enter an IP address and connect directly. Once
-connected, devices automatically exchange an emoji and the attach file icon
-becomes enabled for sending data. On Android, ensure the device is connected to
-Wi-Fi so its IP can be detected.
+connected, devices automatically exchange an emoji and the "Enviar archivo"
+menu option becomes enabled for sending data. On Android, ensure the device is
+connected to Wi-Fi so its IP can be detected.
 
 ### Android permissions
 

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -1,0 +1,56 @@
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key, required this.currentPath});
+
+  final String? currentPath;
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  String? _path;
+
+  @override
+  void initState() {
+    super.initState();
+    _path = widget.currentPath;
+  }
+
+  Future<void> _choosePath() async {
+    final dir = await FilePicker.platform.getDirectoryPath();
+    if (dir != null) {
+      setState(() => _path = dir);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(_path == null
+                ? 'Using default downloads directory.'
+                : 'Save files to: $_path'),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: _choosePath,
+              child: const Text('Choose directory'),
+            ),
+            const Spacer(),
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pop(_path),
+              child: const Text('Done'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/settings_service.dart
+++ b/lib/settings_service.dart
@@ -1,0 +1,19 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SettingsService {
+  static const _downloadKey = 'download_path';
+
+  Future<String?> loadDownloadPath() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_downloadKey);
+  }
+
+  Future<void> saveDownloadPath(String? path) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (path == null) {
+      await prefs.remove(_downloadKey);
+    } else {
+      await prefs.setString(_downloadKey, path);
+    }
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,8 +7,10 @@ import Foundation
 
 import file_picker
 import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
     sdk: flutter
   file_picker: ^10.2.0
   path_provider: ^2.1.2
+  shared_preferences: ^2.2.2
+  open_filex: ^4.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add shared preferences and open_filex dependencies
- implement SettingsService for persisting download directory
- create SettingsPage to pick directory using FilePicker
- allow ConnectionService to use custom storage path and open files from progress list
- move connect/send actions into a popup menu and add Settings option
- document new features in README

## Testing
- `flutter pub get`
- `dart format lib`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_686261914f248322b8c8bad4330aa64d