### PR TITLE
Fix duplicate WebRTC SDP answer handling

### DIFF
--- a/lib/webrtc_service.dart
+++ b/lib/webrtc_service.dart
@@ -101,6 +101,10 @@ class WebRTCService {
           data['sdp'] as String,
           data['type'] as String,
         );
+        if (desc.type == 'answer') {
+          final current = await _peer!.getRemoteDescription();
+          if (current != null) return;
+        }
         await _peer!.setRemoteDescription(desc);
         if (desc.type == 'offer') {
           final answer = await _peer!.createAnswer();


### PR DESCRIPTION
## Summary
- avoid setting a remote WebRTC answer twice

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68669994e63883229dbff18f2bbc2627