### PR TITLE
Fix data channel cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,7 @@ modify the project, ensure `com.apple.security.network.client` and
 To access files chosen via the dialog and save incoming files in `Downloads`
 also enable `com.apple.security.files.user-selected.read-write` and
 `com.apple.security.files.downloads.read-write`.
+
+### Stability Improvements
+
+- Fixed a crash that occurred when the data channel was closed after the peer connection ended.

--- a/lib/webrtc_service.dart
+++ b/lib/webrtc_service.dart
@@ -215,7 +215,13 @@ class WebRTCService {
 
   void dispose() {
     _fileSink?.close();
-    _channel?.close();
+    try {
+      _channel?.close();
+    } catch (e) {
+      debugLog('Error closing data channel: $e');
+    }
     _peer?.close();
+    _channel = null;
+    _peer = null;
   }
 }


### PR DESCRIPTION
## Summary
- avoid crashing when closing data channel after the peer connection ends
- document stability improvement in README

## Testing
- `apt-get update` *(dependency step)*
- ❌ `flutter format lib/webrtc_service.dart` *(command not found)*
- ❌ `dart format lib/webrtc_service.dart` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6866a9df174c8322a0234e34fc7232ac