### PR TITLE
Fix remoteDescription check

### DIFF
--- a/lib/webrtc_service.dart
+++ b/lib/webrtc_service.dart
@@ -138,7 +138,8 @@ class WebRTCService {
             data['sdpMid'] as String?,
             data['sdpMLineIndex'] as int?,
           );
-          if (_peer!.remoteDescription == null) {
+          final current = await _peer!.getRemoteDescription();
+          if (current == null) {
             _pendingCandidates.add(cand);
             debugLog('Queued ICE candidate');
           } else {


### PR DESCRIPTION
## Summary
- fix WebRTC ICE candidate queueing by using `getRemoteDescription()`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866be502eec83229c0ae7374e1b202a