### PR TITLE
Fix WebRTC remote description crash

### DIFF
--- a/lib/webrtc_service.dart
+++ b/lib/webrtc_service.dart
@@ -115,7 +115,12 @@ class WebRTCService {
           data['type'] as String,
         );
         if (desc.type == 'answer') {
-          final current = await _peer!.getRemoteDescription();
+          RTCSessionDescription? current;
+          try {
+            current = await _peer!.getRemoteDescription();
+          } catch (_) {
+            current = null;
+          }
           if (current != null) return;
         }
         await _peer!.setRemoteDescription(desc);
@@ -138,7 +143,12 @@ class WebRTCService {
             data['sdpMid'] as String?,
             data['sdpMLineIndex'] as int?,
           );
-          final current = await _peer!.getRemoteDescription();
+          RTCSessionDescription? current;
+          try {
+            current = await _peer!.getRemoteDescription();
+          } catch (_) {
+            current = null;
+          }
           if (current == null) {
             _pendingCandidates.add(cand);
             debugLog('Queued ICE candidate');


### PR DESCRIPTION
## Summary
- prevent crash when getting remote description in `WebRTCService`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c0969a0883229c7f313c54b8a025