### PR TITLE
Add logo support and GPLv3 headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
+Copyright (C) 2025 Pablo Javier Etcheverry
+
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.

--- a/README.md
+++ b/README.md
@@ -61,3 +61,15 @@ modify the project, ensure `com.apple.security.network.client` and
 To access files chosen via the dialog and save incoming files in `Downloads`
 also enable `com.apple.security.files.user-selected.read-write` and
 `com.apple.security.files.downloads.read-write`.
+
+## Logo
+
+Place your application logo at `assets/logo.png` in PNG format. A size of
+256x256 pixels or larger is recommended. The logo is displayed on the home
+screen when the app launches. Update `pubspec.yaml` if you rename the file or
+use additional formats.
+
+## License
+
+OpenDrop is distributed under the terms of the GNU General Public License
+version 3. See the [LICENSE](LICENSE) file for full details.

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,2 @@
+Add a `logo.png` image here to display in the application.
+Recommended size is at least 256x256 pixels in PNG format.

--- a/lib/debug.dart
+++ b/lib/debug.dart
@@ -1,3 +1,19 @@
+// OpenDrop - Local network file sharing app
+// Copyright (C) 2025 Pablo Javier Etcheverry
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 library opendrop_debug;
 
 bool debugEnabled = false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,19 @@
+// OpenDrop - Local network file sharing app
+// Copyright (C) 2025 Pablo Javier Etcheverry
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -718,6 +734,10 @@ class _HomePageState extends State<HomePage> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                Image.asset(
+                  'assets/logo.png',
+                  height: 80,
+                ),
                 if (_localIp != null) Text('Your IP: $_localIp'),
                 const SizedBox(height: 4),
                 if (_remoteIp != null && _remoteEmoji != null)

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -1,3 +1,19 @@
+// OpenDrop - Local network file sharing app
+// Copyright (C) 2025 Pablo Javier Etcheverry
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 

--- a/lib/settings_service.dart
+++ b/lib/settings_service.dart
@@ -1,3 +1,19 @@
+// OpenDrop - Local network file sharing app
+// Copyright (C) 2025 Pablo Javier Etcheverry
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import 'package:shared_preferences/shared_preferences.dart';
 
 class SettingsService {

--- a/lib/webrtc_service.dart
+++ b/lib/webrtc_service.dart
@@ -1,3 +1,19 @@
+// OpenDrop - Local network file sharing app
+// Copyright (C) 2025 Pablo Javier Etcheverry
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import 'dart:async';
 import 'dart:io';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,3 +21,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/logo.png


### PR DESCRIPTION
## Summary
- document where to place a logo and update license information
- reference logo asset from the app
- add GPLv3 license headers with authorship
- include assets section in `pubspec.yaml`

## Testing
- `dart format lib pubspec.yaml README.md assets/README.md LICENSE` *(fails: command not found)*
- `flutter format lib pubspec.yaml README.md assets/README.md LICENSE` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c2f7b7508322836c48b95b797a67