### PR TITLE
Fix data channel buffer check

### DIFF
--- a/lib/webrtc_service.dart
+++ b/lib/webrtc_service.dart
@@ -260,7 +260,8 @@ class WebRTCService {
 
   Future<void> _waitForBuffer() async {
     while (_channel != null &&
-        _channel!.bufferedAmount >= _channel!.bufferedAmountLowThreshold) {
+        _channel!.bufferedAmount >=
+            (_channel!.bufferedAmountLowThreshold ?? 0)) {
       await Future.delayed(const Duration(milliseconds: 50));
     }
   }


### PR DESCRIPTION
## Summary
- fix null comparison in `_waitForBuffer`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866dce656ac8322bd00079767e1d4c1