### PR TITLE
Fix null-check for bufferedAmount

### DIFF
--- a/lib/webrtc_service.dart
+++ b/lib/webrtc_service.dart
@@ -260,7 +260,7 @@ class WebRTCService {
 
   Future<void> _waitForBuffer() async {
     while (_channel != null &&
-        _channel!.bufferedAmount >=
+        (_channel!.bufferedAmount ?? 0) >=
             (_channel!.bufferedAmountLowThreshold ?? 0)) {
       await Future.delayed(const Duration(milliseconds: 50));
     }


### PR DESCRIPTION
## Summary
- fix potential null check error when waiting for the RTC buffer

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ddd2b44c83229ea1246dc0e69853