### PR TITLE
Improve handling of closed data channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ OpenDrop is a cross-platform file sharing app built with Flutter. It allows user
 - Received files are saved in your chosen directory (defaulting to Downloads).
   Each transfer shows a progress bar with percentage and can be cancelled.
   Progress is visible on both sending and receiving ends. The app automatically
--  retries sending if the connection drops until the transfer completes or is
-    cancelled. Transfers now use WebRTC data channels for greater reliability
-    through the `flutter_webrtc` 0.14 plugin. Large transfers throttle
-    the data channel buffer to avoid premature connection closes.
+  retries sending if the connection drops until the transfer completes or is
+  cancelled. Transfers now use WebRTC data channels for greater reliability
+  through the `flutter_webrtc` 0.14 plugin. Large transfers throttle the data
+  channel buffer to avoid premature connection closes. If the data channel
+  closes unexpectedly, the transfer aborts instead of looping indefinitely.
 - A Settings screen lets you pick the folder used to store transfers and the
   choice persists between launches.
 


### PR DESCRIPTION
## Summary
- handle data channel closing in `WebRTCService`
- exit send loop if the channel closes
- document data channel close behavior in README

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866dfd016008322b43d724849d134c7