### PR TITLE
Fix duplicate completion error when data channel closes

### DIFF
--- a/lib/webrtc_service.dart
+++ b/lib/webrtc_service.dart
@@ -122,7 +122,10 @@ class WebRTCService {
       if (state == RTCDataChannelState.RTCDataChannelClosing ||
           state == RTCDataChannelState.RTCDataChannelClosed) {
         _sendingFile = false;
-        _ackCompleter?.completeError(StateError('channel closed'));
+        if (_ackCompleter != null && !_ackCompleter!.isCompleted) {
+          _ackCompleter!.completeError(StateError('channel closed'));
+          _ackCompleter = null;
+        }
       }
     };
   }


### PR DESCRIPTION
## Summary
- avoid calling `completeError` multiple times when data channel closes

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e2dd5fe88322a5c559525b7602ad