### PR TITLE
Reduce WebRTC send buffer threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ OpenDrop is a cross-platform file sharing app built with Flutter. It allows user
   retries sending if the connection drops until the transfer completes or is
   cancelled. Transfers now use WebRTC data channels for greater reliability
   through the `flutter_webrtc` 0.14 plugin. Large transfers throttle the data
-  channel buffer to avoid premature connection closes. If the data channel
+  channel buffer (now 64&nbsp;KB) to avoid premature connection closes. If the data channel
   closes unexpectedly, the transfer aborts instead of looping indefinitely.
 - A Settings screen lets you pick the folder used to store transfers and the
   choice persists between launches.

--- a/lib/webrtc_service.dart
+++ b/lib/webrtc_service.dart
@@ -109,7 +109,9 @@ class WebRTCService {
   void _setupChannel() {
     if (_channel == null) return;
     debugLog('Setting up data channel');
-    _channel!.bufferedAmountLowThreshold = 1024 * 1024;
+    // Throttle when the channel buffer exceeds 64 KB to prevent premature
+    // closes on some platforms.
+    _channel!.bufferedAmountLowThreshold = 64 * 1024;
     _channel!.onMessage = (message) {
       if (message.isBinary) {
         _handleBinary(message.binary);


### PR DESCRIPTION
## Summary
- lower data channel bufferedAmount threshold to 64KB
- document new buffer limit in README

## Testing
- `dart format -o none lib/webrtc_service.dart README.md` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e5b758e8832291aa316024eb78a7