### PR TITLE
Handle closed data channel gracefully

### DIFF
--- a/lib/webrtc_service.dart
+++ b/lib/webrtc_service.dart
@@ -126,6 +126,7 @@ class WebRTCService {
         _sendingFile = false;
         if (_ackCompleter != null && !_ackCompleter!.isCompleted) {
           _ackCompleter!.completeError(StateError('channel closed'));
+          unawaited(_ackCompleter!.future.catchError((_) {}));
           _ackCompleter = null;
         }
       }


### PR DESCRIPTION
## Summary
- prevent unhandled exception when WebRTC data channel closes unexpectedly

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e92f48ac832284222b665b0df9fa