### PR TITLE
Adjust WebRTC transfer buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ OpenDrop is a cross-platform file sharing app built with Flutter. It allows user
   retries sending if the connection drops until the transfer completes or is
   cancelled. Transfers now use WebRTC data channels for greater reliability
   through the `flutter_webrtc` 0.14 plugin. Large transfers throttle the data
-  channel buffer (now 64&nbsp;KB) to avoid premature connection closes. If the data channel
+  channel buffer (now 256&nbsp;KB) to avoid premature connection closes while
+  sending smaller 16&nbsp;KB chunks. If the data channel
   closes unexpectedly, the transfer aborts instead of looping indefinitely.
 - A Settings screen lets you pick the folder used to store transfers and the
   choice persists between launches.


### PR DESCRIPTION
## Summary
- buffer 256KB to avoid premature WebRTC closes
- send files in 16KB chunks via WebRTC and TCP
- document new behavior in README

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ecef87a88322bcfaa5c895243a6a