### PR TITLE
Fix large file transfer reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ OpenDrop is a cross-platform file sharing app built with Flutter. It allows user
   retries sending if the connection drops until the transfer completes or is
   cancelled. Transfers now use WebRTC data channels for greater reliability
   through the `flutter_webrtc` 0.14 plugin. Large transfers throttle the data
-  channel buffer (now 256&nbsp;KB) to avoid premature connection closes while
-  sending smaller 16&nbsp;KB chunks. If the data channel
+  channel buffer (now 128&nbsp;KB) to avoid premature connection closes while
+  sending smaller 16&nbsp;KB chunks. The sender waits for the buffer to drop
+  below this threshold after each chunk. If the data channel
   closes unexpectedly, the transfer aborts instead of looping indefinitely.
 - A Settings screen lets you pick the folder used to store transfers and the
   choice persists between launches.


### PR DESCRIPTION
## Summary
- tune data channel buffer to 128 KB
- wait for the buffer after each send
- document new behaviour in README

## Testing
- `flutter format lib/webrtc_service.dart README.md`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_68672cdeef108322bde84ea2269c6474