### PR TITLE
Fix large file transfer reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ OpenDrop is a cross-platform file sharing app built with Flutter. It allows user
   retries sending if the connection drops until the transfer completes or is
   cancelled. Transfers now use WebRTC data channels for greater reliability
   through the `flutter_webrtc` 0.14 plugin. Large transfers throttle the data
-  channel buffer (now 256&nbsp;KB) to avoid premature connection closes while
-  sending smaller 16&nbsp;KB chunks. If the data channel
+  channel buffer (now 32&nbsp;KB) to avoid premature connection closes while
+  sending smaller 8&nbsp;KB chunks. The sender waits for the buffer to drop
+  below this threshold after each chunk. If the data channel
   closes unexpectedly, the transfer aborts instead of looping indefinitely.
 - A Settings screen lets you pick the folder used to store transfers and the
   choice persists between launches.

--- a/lib/webrtc_service.dart
+++ b/lib/webrtc_service.dart
@@ -110,10 +110,10 @@ class WebRTCService {
   void _setupChannel() {
     if (_channel == null) return;
     debugLog('Setting up data channel');
-    // Throttle when the channel buffer exceeds 256 KB to prevent premature
-    // closes on some platforms. This value was increased from 64 KB to allow
-    // bigger buffers when sending large files.
-    _channel!.bufferedAmountLowThreshold = 256 * 1024;
+    // Throttle when the channel buffer exceeds 32 KB to prevent premature
+    // closes on some platforms. This lower threshold keeps the backlog small
+    // so the channel isn't overwhelmed during very large transfers.
+    _channel!.bufferedAmountLowThreshold = 32 * 1024;
     _channel!.onMessage = (message) {
       if (message.isBinary) {
         _handleBinary(message.binary);
@@ -255,7 +255,7 @@ class WebRTCService {
         break;
       }
       _channel!.send(RTCDataChannelMessage('FILE:$name:$_totalToSend'));
-      const chunkSize = 16 * 1024;
+      const chunkSize = 8 * 1024;
       final raf = await file.open();
       try {
         while (_bytesSent < _totalToSend) {
@@ -270,7 +270,8 @@ class WebRTCService {
           final bytes = await raf.read(min(chunkSize, remaining));
           if (bytes.isEmpty) break;
 
-          // Wait for the buffered amount to drop to avoid closing the channel
+          // Wait for the buffered amount to drop before sending to avoid
+          // overwhelming the channel on platforms with small buffers.
           await _waitForBuffer();
           if (!_channelOpen) {
             debugLog('Data channel closed before sending chunk');
@@ -283,6 +284,10 @@ class WebRTCService {
           _bytesSent += bytes.length;
           onSendProgress?.call(_bytesSent, _totalToSend);
           debugLog('Sent ${bytes.length} bytes');
+
+          // Wait again to ensure the buffered amount drops after sending. This
+          // helps prevent abrupt channel closure with very large transfers.
+          await _waitForBuffer();
         }
       } finally {
         await raf.close();


### PR DESCRIPTION
## Summary
- throttle WebRTC buffer to 32 KB
- shrink chunk size to 8 KB
- document updated values in README

## Testing
- `flutter format lib/webrtc_service.dart README.md` *(fails: flutter not installed)*
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68672cdeef108322bde84ea2269c6474