### PR TITLE
feat: Implement reliable file transfer and enhance debugging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to OpenDrop
+
+First off, thank you for considering contributing to OpenDrop! It’s people like you that make the open source community such a great place.
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+If you find a bug, please open an issue on GitHub and provide the following information:
+
+*   A clear and descriptive title.
+*   A detailed description of the bug, including steps to reproduce it.
+*   The version of the app you are using.
+*   The operating system you are using.
+*   Any relevant logs or screenshots.
+
+### Suggesting Enhancements
+
+If you have an idea for an enhancement, please open an issue on GitHub and provide the following information:
+
+*   A clear and descriptive title.
+*   A detailed description of the enhancement you are proposing.
+*   Any mockups or screenshots that might help explain your idea.
+
+### Pull Requests
+
+If you want to contribute code, please follow these steps:
+
+1.  Fork the repository and create a new branch from `main`.
+2.  Make your changes, making sure to follow the coding style of the project.
+3.  Write tests for your changes.
+4.  Make sure all tests pass.
+5.  Open a pull request with a clear and descriptive title and a detailed description of your changes.
+
+## Development Setup
+
+To get started with development, you will need to have Flutter installed on your system. You can find instructions on how to install Flutter [here](https://flutter.dev/docs/get-started/install).
+
+Once you have Flutter installed, you can clone the repository and run the app with the following commands:
+
+```bash
+git clone https://github.com/your-username/opendrop.git
+cd opendrop
+flutter run
+```
+
+## Coding Style
+
+This project follows the official [Dart style guide](https://dart.dev/guides/language/effective-dart/style). Please make sure your code adheres to this style guide before submitting a pull request.
+
+We also use the `flutter_lints` package to enforce a consistent coding style. You can run the linter with the following command:
+
+```bash
+flutter analyze
+```
+
+Thank you for your contributions!

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,21 @@
+# OpenDrop To-Do List
+
+This file contains a list of tasks that need to be completed for the OpenDrop app.
+
+## High Priority
+
+*   [ ] Remove the button for searching peers since that is being done automatically.
+*   [ ] Add and test iOS version.
+*   [ ] Add and test Linux version.
+*   [ ] Add and test Windows version.
+
+## Medium Priority
+
+*   [ ] Implement a more robust error handling system.
+*   [ ] Improve the UI to provide more feedback to the user during file transfers.
+*   [ ] Add a way to cancel a file transfer in progress.
+
+## Low Priority
+
+*   [ ] Add a settings page to configure the app.
+*   [ ] Add a way to view the history of file transfers.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
     <application
         android:label="opendrop"
         android:name="${applicationName}"

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '12.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/debug.dart
+++ b/lib/debug.dart
@@ -11,16 +11,89 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License
+// You should have received a copy of the GNU GPL
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 library opendrop_debug;
 
-bool debugEnabled = false;
+import 'package:flutter/foundation.dart';
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+
+FileLogger? _fileLogger;
+
+class FileLogger {
+  FileLogger(this._logFile);
+
+  final File _logFile;
+  IOSink? _sink;
+
+  Future<void> init() async {
+    _sink = _logFile.openWrite(mode: FileMode.append);
+  }
+
+  void log(String message) {
+    _sink?.writeln('${DateTime.now()}: $message');
+  }
+
+  Future<void> dispose() async {
+    await _sink?.flush();
+    await _sink?.close();
+    _sink = null;
+  }
+}
 
 void debugLog(String message) {
-  if (debugEnabled) {
+  if (kDebugMode) {
     // ignore: avoid_print
     print('[DEBUG] $message');
+    _fileLogger?.log(message); // Log to file if logger is initialized
   }
+}
+
+// Function to initialize the file logger
+Future<void> initializeFileLogger(String instanceName, {String? logDirectoryPath}) async {
+  if (kDebugMode) {
+    // ignore: avoid_print
+    print('[DEBUG] Attempting to initialize file logger for instance: $instanceName');
+    // ignore: avoid_print
+    print('[DEBUG] Provided logDirectoryPath: $logDirectoryPath');
+    try {
+      Directory baseDir;
+      if (logDirectoryPath != null && logDirectoryPath.isNotEmpty) {
+        baseDir = Directory(logDirectoryPath);
+        // ignore: avoid_print
+        print('[DEBUG] Using provided logDirectoryPath as baseDir: ${baseDir.path}');
+      } else {
+        baseDir = await getApplicationSupportDirectory();
+        // ignore: avoid_print
+        print('[DEBUG] Using getApplicationSupportDirectory as baseDir: ${baseDir.path}');
+      }
+      final logDir = Directory('${baseDir.path}/logs');
+      // ignore: avoid_print
+      print('[DEBUG] Log directory path: ${logDir.path}');
+      if (!await logDir.exists()) {
+        // ignore: avoid_print
+        print('[DEBUG] Log directory does not exist, creating: ${logDir.path}');
+        await logDir.create(recursive: true);
+        // ignore: avoid_print
+        print('[DEBUG] Log directory created.');
+      }
+      final logFile = File('${logDir.path}/opendrop_debug_${instanceName}_${DateTime.now().millisecondsSinceEpoch}.log');
+      // ignore: avoid_print
+      print('[DEBUG] Log file path: ${logFile.path}');
+      _fileLogger = FileLogger(logFile);
+      await _fileLogger?.init();
+      debugLog('File logging initialized to: ${logFile.path}');
+    } catch (e) {
+      // ignore: avoid_print
+      print('Error initializing file logger: $e');
+    }
+  }
+}
+
+// Function to dispose the file logger
+Future<void> disposeFileLogger() async {
+  await _fileLogger?.dispose();
+  _fileLogger = null;
 }

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.14'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,0 +1,49 @@
+PODS:
+  - file_picker (0.0.1):
+    - FlutterMacOS
+  - flutter_webrtc (0.14.0):
+    - FlutterMacOS
+    - WebRTC-SDK (= 125.6422.07)
+  - FlutterMacOS (1.0.0)
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - WebRTC-SDK (125.6422.07)
+
+DEPENDENCIES:
+  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
+  - flutter_webrtc (from `Flutter/ephemeral/.symlinks/plugins/flutter_webrtc/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+
+SPEC REPOS:
+  trunk:
+    - WebRTC-SDK
+
+EXTERNAL SOURCES:
+  file_picker:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
+  flutter_webrtc:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_webrtc/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+
+SPEC CHECKSUMS:
+  file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
+  flutter_webrtc: a7eeb54859e672228c28f4b48b1fb61561976ea3
+  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  WebRTC-SDK: dff00a3892bc570b6014e046297782084071657e
+
+PODFILE CHECKSUM: 7eb978b976557c8c1cd717d8185ec483fd090a82
+
+COCOAPODS: 1.16.2

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		9CF942A7233277BC6D4D9892 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 944D57D5489D0C3066F625A4 /* Pods_RunnerTests.framework */; };
+		C787F4A3D0E61572DE83BA21 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEA150383E7CA7A0F2256DE1 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,11 +62,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0966D83499E26C0656FBD1C4 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-             33CC10ED2044A3C60003C045 /* opendrop.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "opendrop.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* opendrop.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = opendrop.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -76,8 +79,15 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		50E4F8191415123DF3801619 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		7EDC956B53A1006A6797B2C9 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		7FF8EBF10F95AF564B83522F /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		944D57D5489D0C3066F625A4 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		ED6EEC84FC06D865F89702EB /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		F61B6419947CCC59766248D5 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		FEA150383E7CA7A0F2256DE1 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9CF942A7233277BC6D4D9892 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C787F4A3D0E61572DE83BA21 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,13 +137,14 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				F62D2E9F0618D405F2AF65B4 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-                             33CC10ED2044A3C60003C045 /* opendrop.app */,
+				33CC10ED2044A3C60003C045 /* opendrop.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -175,8 +188,24 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				FEA150383E7CA7A0F2256DE1 /* Pods_Runner.framework */,
+				944D57D5489D0C3066F625A4 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F62D2E9F0618D405F2AF65B4 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				0966D83499E26C0656FBD1C4 /* Pods-Runner.debug.xcconfig */,
+				50E4F8191415123DF3801619 /* Pods-Runner.release.xcconfig */,
+				7FF8EBF10F95AF564B83522F /* Pods-Runner.profile.xcconfig */,
+				ED6EEC84FC06D865F89702EB /* Pods-RunnerTests.debug.xcconfig */,
+				F61B6419947CCC59766248D5 /* Pods-RunnerTests.release.xcconfig */,
+				7EDC956B53A1006A6797B2C9 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -186,6 +215,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				CBF2FC035189FFEF711C7E23 /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,11 +234,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				E123BC4E2E70E551EEE11635 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				38511A4B03B93CE8F8DB8EFD /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -217,7 +249,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-                    productReference = 33CC10ED2044A3C60003C045 /* opendrop.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* opendrop.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -329,6 +361,67 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
+		38511A4B03B93CE8F8DB8EFD /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CBF2FC035189FFEF711C7E23 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E123BC4E2E70E551EEE11635 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -380,43 +473,46 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = ED6EEC84FC06D865F89702EB /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-                            PRODUCT_BUNDLE_IDENTIFIER = com.example.opendrop.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.opendrop.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-                            TEST_HOST = "$(BUILT_PRODUCTS_DIR)/opendrop.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/opendrop";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/opendrop.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/opendrop";
 			};
 			name = Debug;
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F61B6419947CCC59766248D5 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-                            PRODUCT_BUNDLE_IDENTIFIER = com.example.opendrop.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.opendrop.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-                            TEST_HOST = "$(BUILT_PRODUCTS_DIR)/opendrop.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/opendrop";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/opendrop.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/opendrop";
 			};
 			name = Release;
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7EDC956B53A1006A6797B2C9 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-                            PRODUCT_BUNDLE_IDENTIFIER = com.example.opendrop.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.opendrop.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-                            TEST_HOST = "$(BUILT_PRODUCTS_DIR)/opendrop.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/opendrop";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/opendrop.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/opendrop";
 			};
 			name = Profile;
 		};

--- a/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
         <key>com.apple.security.network.client</key>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   path_provider: ^2.1.2
   shared_preferences: ^2.2.2
   open_filex: ^4.0.0
-  flutter_webrtc: ^0.14.1
+  flutter_webrtc: ^0.14.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.0
+  flutter_lints: ^6.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
     This commit introduces a series of improvements to the OpenDrop Flutter application, enabling reliable file transfer
      between macOS and Android devices and enhancing the debugging experience.

     Key changes:
     - Restructured the `_onData` method in `lib/main.dart` to use a `handled` flag, ensuring that only truly unhandled
      messages are passed to the UI's log.
     - Implemented file logging for both macOS and Android, with logs being collected in the project's `logs/` directory.
     - Disabled the macOS app sandbox in `DebugProfile.entitlements` to allow writing logs to the project directory.
     - Added `ACCESS_NETWORK_STATE` and `CHANGE_WIFI_STATE` permissions to the Android manifest.
     - Updated the `flutter_webrtc` dependency to version `0.14.2` to address build issues on macOS.
     - Added a check in the `_HomePageState` to avoid processing key events when the app is not in the foreground.
     - Added `CONTRIBUTING.md` and `TODO.md` files to the project.